### PR TITLE
Add permalink in frontmatter for Developing and Literature pages

### DIFF
--- a/_older-users/developing.md
+++ b/_older-users/developing.md
@@ -15,6 +15,7 @@ footer: >
   <p><strong>Date:</strong> Reviewed January 2018. Updated 22 September 2010. CHANGELOG</p>
   <p><strong>Editors:</strong> <a href="http://www.w3.org/People/Andrew/">Andrew Arch</a> and <a href="http://www.w3.org/People/shadi/">Shadi Abou-Zahra</a>. Contributors: <a href="http://www.w3.org/People/Shawn/">Shawn Henry</a>, Suzette Keith, Kate Roberts. </p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>), with the <a href="http://www.w3.org/WAI/EO/2008/wai-age-tf.html#participants">WAI-AGE Task Force</a>. Related to the  <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> funded by the European Commission under the 6th Framework.</p>
+permalink: /older-users/developing/
 ref: /older-users/developing/
 changelog: /older-users/changelog/
 resource:

--- a/_older-users/literature.md
+++ b/_older-users/literature.md
@@ -15,6 +15,7 @@ footer: >
   <p><strong>Date:</strong> Updated 22 February 2018. First published 2008. CHANGELOG</p>
   <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and <a href="https://www.w3.org/People/Andrew/" >Andrew Arch</a>. Contributors: <a href="https://www.w3.org/People/shadi/">Shadi Abou-Zahra</a> and Vicki Menezes Miller.</p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Related to the  <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> funded by the European Commission under the 6th Framework.</p>
+permalink: /older-users/literature/
 ref: /older-users/literature/
 changelog: /older-users/changelog/
 resource:


### PR DESCRIPTION
Missing permalink in the frontmatter was creating problems. 

It prevented the use of relative URLs like `/older-users/developing` in other English pages on WAI website. See reverted https://github.com/w3c/wai-design-develop-overview/pull/39

Needed to merge https://github.com/w3c/wai-design-develop-overview/pull/41
